### PR TITLE
Reset culture to invariant

### DIFF
--- a/WorldServer/WorldServer.cs
+++ b/WorldServer/WorldServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Common.Constants;
 using Common.Cryptography;
 using Common.Logging;
@@ -14,6 +15,8 @@ namespace WorldServer
 
         private static void Main()
         {
+            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+
             Log.Message(LogType.INIT, "                AIO SANDBOX                ");
             Log.Message(LogType.INIT, "             REALM/PROXY/WORLD             ");
             Log.Message();


### PR DESCRIPTION
Running the server on a Czech system (and most likely also other non-English cultures) throws an exception in `Extensions.SetValueEx`. This is most likely caused by `Convert.ChangeType` trying to convert a floating-point value, however the affected cultures use a comma as the default decimal separator, resulting in the failure.

This change sets the culture of the application and all new threads to one that behaves consistently on all platforms.